### PR TITLE
fix (bin/bench_50.rs, lib.rs): fix clippy warnings

### DIFF
--- a/src/bin/bench_50.rs
+++ b/src/bin/bench_50.rs
@@ -54,7 +54,7 @@ impl<'a> DemoPedersenHashCircuit<'a> {
         j: &'a JubJub
     ) -> DemoPedersenHashCircuit<'a>
     {
-        assert!(bits.len() == 512);
+        assert_eq!(bits.len(), 512);
 
         DemoPedersenHashCircuit {
             bits: bits.iter().map(|&b| Assignment::known(b)).collect(),
@@ -79,7 +79,7 @@ impl<'a> Circuit<Bls12> for DemoPedersenHashCircuit<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<Self::InputMap, Error>
     {
         let mut bits = Vec::with_capacity(512);
-        for b in self.bits.iter() {
+        for b in &self.bits {
             bits.push(Bit::alloc(cs, *b)?);
         }
 
@@ -110,7 +110,7 @@ use std::path::Path;
 
 fn main() {
     let rng = &mut thread_rng();
-    let mut generator_rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let mut generator_rng = XorShiftRng::from_seed([0x5dbe_6259, 0x8d31_3d76, 0x3237_db17, 0xe5bc_0654]);
     let j = JubJub::new();
     println!("Creating random generators for the Pedersen hash...");
     let generators = generate_constant_table(&mut generator_rng, &j);


### PR DESCRIPTION
This commit addresses lint warnings reported by the clippy tool

* warning: you don't need to add `&` to all patterns
* warning: you should consider adding a `Default` implementation for `JubJub`
* warning: 6th binding whose name is just one char
* warning: it is more idiomatic to loop over references to containers instead of using explicit iteration methods
* warning: use `assert_eq` for better reporting
* warning: 5th binding whose name is just one char
* warning: using `clone` on a `Copy` type
* warning: the `a @ _` pattern can be written as just `a`
* warning: this expression borrows a reference that is immediately dereferenced by the compiler
* warning: long literal lacking separators

This changes to do not affect the logic at all, they only write more
idiomatic rust :-)

references:
--

* https://github.com/rust-lang-nursery/rust-clippy
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#explicit_iter_loop
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#many_single_char_names
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#clone_on_copy
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#match_ref_pats
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#needless_borrow
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#should_assert_eq
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#should_assert_eq
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#redundant_pattern
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#new_without_default
* https://rust-lang-nursery.github.io/rust-clippy/v0.0.165/index.html#unreadable_literal